### PR TITLE
Making the project discoverable on pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "graphscii"
+version = "0.1.0"
+description = "ASCII graph visualization library"
+readme = "README.md"
+requires-python = ">=3.6"
+dependencies = [
+    "contourpy==1.2.0",
+    "cycler==0.12.1",
+    "fonttools==4.47.0",
+    "kiwisolver==1.4.5",
+    "matplotlib==3.8.2",
+    "networkx==3.2.1",
+    "numpy==1.26.2",
+    "packaging==23.2",
+    "Pillow==10.1.0",
+    "PuLP==2.7.0",
+    "pyparsing==3.1.1",
+    "python-dateutil==2.8.2",
+    "six==1.16.0"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["graphscii*"]


### PR DESCRIPTION
Hello! Love this library.

I'm preparing for DS&Algorithm interviews and am using this to help me visualize graphs.

I wanted to import this package and use it in my repository. There's another library that's taken up the `graphscii` namespace on pip: https://github.com/etano/graphscii.

However, once the repo has a `pyproject.toml` file, I can add it like so in my `requirements.txt`.

```
git+https://github.com/bharatagarwal/graphscii.git
```

Note: It would change to `git+https://github.com/raybbian/graphscii.git` if you merge this.